### PR TITLE
Systemd unit files for Matlab Distributed Computing Server

### DIFF
--- a/matlab-dcs-jobmanager.service
+++ b/matlab-dcs-jobmanager.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Matlab DCS Job Manager
+After=multi-user.target
+After=matlab-dcs-mdce.service
+
+[Service]
+Type=forking
+RemainAfterExit=True
+ExecStart=/path/to/matlab/toolbox/distcomp/bin/startjobmanager
+ExecStop=/path/to/matlab/toolbox/distcomp/bin/stopjobmanager
+TimeoutSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/matlab-dcs-mdce.service
+++ b/matlab-dcs-mdce.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Matlab MDCE service
+After=multi-user.target
+Before=matlab-dcs-worker.service
+
+[Service]
+Type=forking
+RemainAfterExit=True
+ExecStart=/path/to/matlab/toolbox/distcomp/bin/mdce start
+ExecStop=/path/to/matlab/toolbox/distcomp/bin/mdce stop
+TimeoutSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/matlab-dcs-worker.service
+++ b/matlab-dcs-worker.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Matlab DCS worker service
+After=multi-user.target
+After=matlab-dcs-mdce.service
+
+[Service]
+Type=forking
+RemainAfterExit=True
+ExecStart=/path/to/matlab/2011a/toolbox/distcomp/bin/startworker -v -jobmanagerhost headnode -jobmanager default_jobmanager
+ExecStop=/storage/cluster/versatushpc/softwares/matlab/2011a/toolbox/distcomp/bin/stopworker -v
+TimeoutSec=0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These files are to help the poor soul who, like me,
had to install Matlab's Distributed Computing Server on a Linux using systemd.
The files were only (lightly) tested on a centos 7.4 machine, so YMMV.