### PR TITLE
RemainAfterExit=True → Type=forking

### DIFF
--- a/matlablm.service
+++ b/matlablm.service
@@ -3,7 +3,7 @@ Description=MatlabFlexLM
 
 [Service]
 User=CHANGE_ME
-RemainAfterExit=True
+Type=forking
 ExecStart=/usr/local/MATLAB/R2016b/etc/lmstart
 ExecStop=/usr/local/MATLAB/R2016b/etc/lmdown
 


### PR DESCRIPTION
See discussion here:
https://stackoverflow.com/questions/30640717/systemd-script-does-execstop-right-after-execstart#39969975