### PR TITLE
Restart after a failure

### DIFF
--- a/matlablm.service
+++ b/matlablm.service
@@ -6,6 +6,8 @@ User=CHANGE_ME
 RemainAfterExit=True
 ExecStart=/usr/local/MATLAB/R2016b/etc/lmstart
 ExecStop=/usr/local/MATLAB/R2016b/etc/lmdown
+Restart=on-failure
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The default value for RestartSec is 100 ms. This seems way too short in
the case of FlexNet. Experience shows the lmstart script provided with
MATLAB may fail to restart FlexNet if called too soon after FlexNet is
stopped, as ports may still be in use. The delay may be larger than 60s.
To avoid reaching the rate limit StartLimitBurst, we need the value of
RestartSec to be similar to that delay.

See discussion here:
https://unix.stackexchange.com/questions/289629/systemd-restart-always-is-not-honored#324297

A value of 30s doesn't sound that bad. Checked-out licenses will remain
active. Only checking out new licenses will be deferred.